### PR TITLE
feat: Add visitor counter

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,3 +10,19 @@ services:
       - "9443:443"
     environment:
       - NODE_ENV=production
+    depends_on:
+      - counter-api-prod
+    volumes:
+      - ./src/nuernbergklima/nginx.conf:/etc/nginx/conf.d/default.conf
+
+  counter-api-prod:
+    build:
+      context: ./src/counter-api
+      dockerfile: Dockerfile
+    container_name: counter-api-prod
+    restart: always
+    volumes:
+      - counter-data:/data
+
+volumes:
+  counter-data:

--- a/src/counter-api/Dockerfile
+++ b/src/counter-api/Dockerfile
@@ -1,0 +1,18 @@
+# Base image
+FROM python:3.9-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY app.py .
+
+# Expose port
+EXPOSE 5000
+
+# Run the application
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]

--- a/src/counter-api/app.py
+++ b/src/counter-api/app.py
@@ -1,0 +1,50 @@
+from flask import Flask, jsonify, make_response
+from flask_cors import CORS
+import os
+
+app = Flask(__name__)
+CORS(app)
+
+DATA_DIR = '/data'
+COUNTER_FILE = os.path.join(DATA_DIR, 'counter.txt')
+
+def get_count():
+    if not os.path.exists(COUNTER_FILE):
+        return 0
+    with open(COUNTER_FILE, 'r') as f:
+        try:
+            return int(f.read())
+        except ValueError:
+            return 0
+
+def set_count(count):
+    if not os.path.exists(DATA_DIR):
+        os.makedirs(DATA_DIR)
+    with open(COUNTER_FILE, 'w') as f:
+        f.write(str(count))
+
+@app.route('/api/counter', methods=['GET'])
+def get_visitor_count():
+    count = get_count()
+    return jsonify({'count': count})
+
+@app.route('/api/counter/increment', methods=['POST'])
+def increment_visitor_count():
+    count = get_count()
+    count += 1
+    set_count(count)
+    return jsonify({'count': count})
+
+@app.route('/api/health', methods=['GET'])
+def health_check():
+    return jsonify({'status': 'ok'})
+
+if __name__ == '__main__':
+    # Create the data directory if it doesn't exist
+    if not os.path.exists(DATA_DIR):
+        os.makedirs(DATA_DIR)
+    # Initialize counter file if it doesn't exist
+    if not os.path.exists(COUNTER_FILE):
+        set_count(0)
+
+    app.run(host='0.0.0.0', port=5000)

--- a/src/counter-api/requirements.txt
+++ b/src/counter-api/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-Cors
+gunicorn

--- a/src/nuernbergklima/nginx.conf
+++ b/src/nuernbergklima/nginx.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://counter-api-prod:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/src/nuernbergklima/src/index.html
+++ b/src/nuernbergklima/src/index.html
@@ -230,7 +230,7 @@
 
   <footer class="footer">
     <div class="container">
-      <p>© <span id="year"></span> NuernbergKlima.de by Hackerban.de</p>
+      <p>© <span id="year"></span> NuernbergKlima.de by Hackerban.de | Visitors: <span id="visitor-counter">...</span></p>
     </div>
   </footer>
 
@@ -252,6 +252,32 @@
     // --- Footer Year ---
     document.getElementById('year').textContent = new Date().getFullYear();
 
+    // --- Visitor Counter ---
+    async function updateVisitorCount() {
+      try {
+        // Increment visitor count and get new count in one request
+        const response = await fetch('/api/counter/increment', { method: 'POST' });
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data = await response.json();
+
+        // Update the UI
+        const visitorCountElement = document.getElementById('visitor-counter');
+        if (visitorCountElement) {
+          visitorCountElement.textContent = data.count;
+        }
+      } catch (error) {
+        console.error('Error fetching visitor count:', error);
+        const visitorCountElement = document.getElementById('visitor-counter');
+        if (visitorCountElement) {
+          visitorCountElement.textContent = 'N/A';
+        }
+      }
+    }
+
+    // Update the count when the page loads
+    document.addEventListener('DOMContentLoaded', updateVisitorCount);
     // The map initialization is now expected to be in /scripts/map.js
   </script>
 </body>


### PR DESCRIPTION
This commit introduces a visitor counter to the website.

I created a new microservice, `counter-api`, using Python and Flask to handle the counting logic. The count is stored in a text file and persisted across container restarts using a Docker volume.

The main web application, served by Nginx, is now configured to proxy API requests to the `counter-api` service.

The frontend is updated to call the new API, increment the visitor count on each page load, and display the total count in the footer.

Note: I was unable to build and test the containers due to Docker Hub rate limiting. You will need to build and run them using `docker-compose -f docker-compose.prod.yml up --build`.